### PR TITLE
Fix raise statement to use Exception

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ except:
     try: 
         from Pyrex.Distutils import build_ext
     except: 
-        raise "No Cython or Pyrex found!"
+        raise Exception("No Cython or Pyrex found!")
 
 def setup_python3():
     # Taken from "distribute" setup.py


### PR DESCRIPTION
In Python 2.6+ it is not allowed to raise a str.

This change raises an Exception instead of a str. It is backward compatible with Python 2.5
