### PR TITLE
doc: minor markdown fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Migrated to Python 3 / RDFLib=>6 and adjusted to use the [plyvel](https://pypi.o
 ### Install with pip from github repos
 
 ```bash
-pip install git+https://github.com/RDFLib/rdflib-leveldb#egg=rdflib_leveldb`
+pip install git+https://github.com/RDFLib/rdflib-leveldb#egg=rdflib_leveldb
 ```
 
 ### Install by cloning github repos, then pip install


### PR DESCRIPTION
Presumably the backtick is leftover from a previous markdown change.